### PR TITLE
Support newlines in prompt

### DIFF
--- a/dart/analyzer.py
+++ b/dart/analyzer.py
@@ -187,7 +187,7 @@ class DartAnalyzer:
             self.vocab += escape_webui_special_symbols(self.vocab)
 
     def split_tags(self, image_prompt: str) -> list[str]:
-        return [tag.strip() for tag in image_prompt.split(",") if tag.strip() != ""]
+        return [tag.strip() for tag in image_prompt.split(",") for tag in tag.split("\n") if tag.strip() != ""]
 
     def extract_tags(self, input_tags: list[str], extract_tag_list: list[str]):
         matched: list[str] = []


### PR DESCRIPTION
Without this change, prompts like this:
```
score_9
BREAK
hatsune miku, 1girl
```
Are currently parsed as:
```
["score_9\nBREAK\nhatsune miku", "1girl"]
```

This fixes this issue so they're parsed correctly as:
```
["score_9", "BREAK", "hatsune miku", "1girl"]
```