### PR TITLE
Bypass when using txt2img upscale button

### DIFF
--- a/scripts/dart_upsampler.py
+++ b/scripts/dart_upsampler.py
@@ -293,6 +293,9 @@ class DartUpsampleScript(scripts.Script):
 
         if process_timing != PROCESSING_TIMING["AFTER"]:
             return
+        
+        if getattr(p, 'txt2img_upscale', False):
+            return
 
         analyzing_results = [self.analyzer.analyze(prompt) for prompt in p.all_prompts]
         logger.debug(f"Analyzed: {analyzing_results}")
@@ -376,6 +379,9 @@ class DartUpsampleScript(scripts.Script):
             return
 
         if process_timing != PROCESSING_TIMING["BEFORE"]:
+            return
+        
+        if getattr(p, 'txt2img_upscale', False):
             return
 
         analyzing_result = self.analyzer.analyze(p.prompt)


### PR DESCRIPTION
This prevents tag upsampling being performed on top of the already-upsampled prompt when a user clicks the upscale button in txt2img (part of webui version 1.8.0).

**Edit:** Marking as a draft for now since I realized this isn't actually the proper solution. Something like https://github.com/p1atdev/sd-danbooru-tags-upsampler/issues/15 should be implemented to fix this properly.